### PR TITLE
fix: allow searching words with diacritics

### DIFF
--- a/packages/api/nitro.config.ts
+++ b/packages/api/nitro.config.ts
@@ -2,27 +2,27 @@ import { defineConfig } from "nitro";
 
 // https://nitro.build/config
 export default defineConfig({
-  serverDir: "./",
-  experimental: {
-    openAPI: true,
-  },
-  openAPI: {
-    meta: {
-      title: "Wiktapi",
-      description: "Multilingual dictionary REST API built on Wiktionary data",
-      version: "1",
+    serverDir: "./",
+    experimental: {
+        openAPI: true,
     },
-    production: "runtime",
-  },
-  routeRules: {
-    // All API data is static between dump imports (~monthly).
-    // After re-importing, purge the Cloudflare cache manually:
-    // npx wrangler pages deployment tail  (or via the dashboard → Caching → Purge Everything)
-    "/v1/**": {
-      headers: {
-        "cache-control": "public, max-age=86400, stale-while-revalidate=604800",
-        "access-control-allow-origin": "*",
-      },
+    openAPI: {
+        meta: {
+            title: "Wiktapi",
+            description: "Multilingual dictionary REST API built on Wiktionary data",
+            version: "1",
+        },
+        production: "runtime",
     },
-  },
+    routeRules: {
+        // All API data is static between dump imports (~monthly).
+        // After re-importing, purge the Cloudflare cache manually:
+        // npx wrangler pages deployment tail  (or via the dashboard → Caching → Purge Everything)
+        "/v1/**": {
+            headers: {
+                "cache-control": "public, max-age=86400, stale-while-revalidate=604800",
+                "access-control-allow-origin": "*",
+            },
+        },
+    },
 });

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@wiktapi/api",
-  "license": "MIT",
-  "type": "module",
-  "scripts": {
-    "build": "nitro build",
-    "dev": "nitro dev",
-    "preview": "npx srvx --prod .output/",
-    "test": "vp test run",
-    "download": "node scripts/download_kaikki.ts",
-    "import": "node scripts/import_data.ts",
-    "import:staging": "node scripts/import_data.ts --output data/wiktionary.db.new --fresh --skip-indexes",
-    "index": "node scripts/build_indexes.ts",
-    "index:staging": "node scripts/build_indexes.ts --output data/wiktionary.db.new",
-    "swap": "mv data/wiktionary.db.new data/wiktionary.db"
-  },
-  "dependencies": {
-    "better-sqlite3": "^12.6.2",
-    "effect": "^3.19.18"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
-    "nitro": "latest",
-    "rolldown": "latest",
-    "vite-plus": "catalog:",
-    "vitest": "catalog:"
-  }
+    "name": "@wiktapi/api",
+    "license": "MIT",
+    "type": "module",
+    "scripts": {
+        "build": "nitro build",
+        "dev": "nitro dev",
+        "preview": "npx srvx --prod .output/",
+        "test": "vp test run",
+        "download": "node scripts/download_kaikki.ts",
+        "import": "node scripts/import_data.ts",
+        "import:staging": "node scripts/import_data.ts --output data/wiktionary.db.new --fresh --skip-indexes",
+        "index": "node scripts/build_indexes.ts",
+        "index:staging": "node scripts/build_indexes.ts --output data/wiktionary.db.new",
+        "swap": "mv data/wiktionary.db.new data/wiktionary.db"
+    },
+    "dependencies": {
+        "better-sqlite3": "^12.6.2",
+        "effect": "^3.19.18"
+    },
+    "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "nitro": "latest",
+        "rolldown": "latest",
+        "vite-plus": "catalog:",
+        "vitest": "catalog:"
+    }
 }

--- a/packages/api/plugins/db.ts
+++ b/packages/api/plugins/db.ts
@@ -2,7 +2,7 @@ import { definePlugin } from "nitro";
 import { db } from "../utils/db";
 
 export default definePlugin((nitroApp) => {
-  nitroApp.hooks.hook("close", () => {
-    db.close();
-  });
+    nitroApp.hooks.hook("close", () => {
+        db.close();
+    });
 });

--- a/packages/api/routes/v1/[edition]/search.get.ts
+++ b/packages/api/routes/v1/[edition]/search.get.ts
@@ -3,97 +3,97 @@ import { defineHandler, getRouterParam, getQuery, createError } from "nitro/h3";
 import { db } from "../../../utils/db";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Search"],
-    summary: "Prefix search",
-    description:
-      "Returns up to 50 words that start with the given prefix, optionally filtered by language.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "query",
-        name: "q",
-        required: true,
-        schema: { type: "string" },
-        description: "Search prefix.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                results: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      word: { type: "string" },
-                      lang_code: { type: "string" },
-                      lang: { type: "string", nullable: true },
-                      pos: { type: "string", nullable: true },
-                    },
-                  },
-                },
-              },
+    openAPI: {
+        tags: ["Search"],
+        summary: "Prefix search",
+        description:
+            "Returns up to 50 words that start with the given prefix, optionally filtered by language.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "query",
+                name: "q",
+                required: true,
+                schema: { type: "string" },
+                description: "Search prefix.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                results: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            word: { type: "string" },
+                                            lang_code: { type: "string" },
+                                            lang: { type: "string", nullable: true },
+                                            pos: { type: "string", nullable: true },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            400: { description: "Missing required query param `q`." },
         },
-      },
-      400: { description: "Missing required query param `q`." },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const { q, lang } = getQuery(event) as { q?: string; lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const { q, lang } = getQuery(event) as { q?: string; lang?: string };
 
-  if (!q) {
-    throw createError({ statusCode: 400, message: "Missing required query param: q" });
-  }
+    if (!q) {
+        throw createError({ statusCode: 400, message: "Missing required query param: q" });
+    }
 
-  const prefix = q.toLowerCase().replace(/[%_]/g, "\\$&") + "%";
+    const prefix = q.toLowerCase().replace(/[%_]/g, "\\$&") + "%";
 
-  type Row = { word: string; lang_code: string; lang: string | null; pos: string | null };
+    type Row = { word: string; lang_code: string; lang: string | null; pos: string | null };
 
-  const rows = (
-    lang
-      ? db
-          .prepare(
-            `SELECT DISTINCT word, lang_code, lang, pos
+    const rows = (
+        lang
+            ? db
+                  .prepare(
+                      `SELECT DISTINCT word, lang_code, lang, pos
              FROM entries
              WHERE edition = ? AND lower(word) LIKE ? ESCAPE '\\' AND lang_code = ?
              ORDER BY word
              LIMIT 50`,
-          )
-          .all(edition, prefix, lang)
-      : db
-          .prepare(
-            `SELECT DISTINCT word, lang_code, lang, pos
+                  )
+                  .all(edition, prefix, lang)
+            : db
+                  .prepare(
+                      `SELECT DISTINCT word, lang_code, lang, pos
              FROM entries
              WHERE edition = ? AND lower(word) LIKE ? ESCAPE '\\'
              ORDER BY word
              LIMIT 50`,
-          )
-          .all(edition, prefix)
-  ) as Row[];
+                  )
+                  .all(edition, prefix)
+    ) as Row[];
 
-  return { results: rows };
+    return { results: rows };
 });

--- a/packages/api/routes/v1/[edition]/word/[word].get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word].get.ts
@@ -3,68 +3,68 @@ import { defineHandler, getRouterParam, getQuery } from "nitro/h3";
 import { fetchWordEntries } from "../../../../utils/queries";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Word"],
-    summary: "Full word entry",
-    description:
-      "Returns the full raw Wiktionary entry for a word. Each item in `entries` is the complete parsed JSON from kaikki.org.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "path",
-        name: "word",
-        required: true,
-        schema: { type: "string" },
-        description: "The word to look up.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                word: { type: "string" },
-                edition: { type: "string" },
-                entries: {
-                  type: "array",
-                  items: { type: "object" },
-                  description: "Full kaikki.org entry objects.",
-                },
-              },
+    openAPI: {
+        tags: ["Word"],
+        summary: "Full word entry",
+        description:
+            "Returns the full raw Wiktionary entry for a word. Each item in `entries` is the complete parsed JSON from kaikki.org.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "path",
+                name: "word",
+                required: true,
+                schema: { type: "string" },
+                description: "The word to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                word: { type: "string" },
+                                edition: { type: "string" },
+                                entries: {
+                                    type: "array",
+                                    items: { type: "object" },
+                                    description: "Full kaikki.org entry objects.",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
-      },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word", { decode: true })!;
-  const { lang } = getQuery(event) as { lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const word = getRouterParam(event, "word", { decode: true })!;
+    const { lang } = getQuery(event) as { lang?: string };
 
-  const entries = fetchWordEntries(edition, word, lang).map((r) => ({
-    senses: JSON.parse(r.senses),
-    sounds: JSON.parse(r.sounds ?? "[]"),
-    translations: JSON.parse(r.translations ?? "[]"),
-    forms: JSON.parse(r.forms ?? "[]"),
-  }));
-  return { word, edition, entries };
+    const entries = fetchWordEntries(edition, word, lang).map((r) => ({
+        senses: JSON.parse(r.senses),
+        sounds: JSON.parse(r.sounds ?? "[]"),
+        translations: JSON.parse(r.translations ?? "[]"),
+        forms: JSON.parse(r.forms ?? "[]"),
+    }));
+    return { word, edition, entries };
 });

--- a/packages/api/routes/v1/[edition]/word/[word].get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word].get.ts
@@ -57,7 +57,7 @@ defineRouteMeta({
 
 export default defineHandler((event) => {
   const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word")!;
+  const word = getRouterParam(event, "word", { decode: true })!;
   const { lang } = getQuery(event) as { lang?: string };
 
   const entries = fetchWordEntries(edition, word, lang).map((r) => ({

--- a/packages/api/routes/v1/[edition]/word/[word]/definitions.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/definitions.get.ts
@@ -3,88 +3,97 @@ import { defineHandler, getRouterParam, getQuery } from "nitro/h3";
 import { fetchWordEntries } from "../../../../../utils/queries";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Word"],
-    summary: "Word definitions",
-    description:
-      "Returns senses (glosses, examples, tags) for each part-of-speech entry of the word.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "path",
-        name: "word",
-        required: true,
-        schema: { type: "string" },
-        description: "The word to look up.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                word: { type: "string" },
-                edition: { type: "string" },
-                definitions: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      pos: { type: "string", example: "noun" },
-                      lang_code: { type: "string", example: "de" },
-                      senses: {
-                        type: "array",
-                        items: {
-                          type: "object",
-                          properties: {
-                            glosses: { type: "array", items: { type: "string" } },
-                            examples: { type: "array", items: { type: "object" } },
-                            tags: { type: "array", items: { type: "string" } },
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
+    openAPI: {
+        tags: ["Word"],
+        summary: "Word definitions",
+        description:
+            "Returns senses (glosses, examples, tags) for each part-of-speech entry of the word.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "path",
+                name: "word",
+                required: true,
+                schema: { type: "string" },
+                description: "The word to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                word: { type: "string" },
+                                edition: { type: "string" },
+                                definitions: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            pos: { type: "string", example: "noun" },
+                                            lang_code: { type: "string", example: "de" },
+                                            senses: {
+                                                type: "array",
+                                                items: {
+                                                    type: "object",
+                                                    properties: {
+                                                        glosses: {
+                                                            type: "array",
+                                                            items: { type: "string" },
+                                                        },
+                                                        examples: {
+                                                            type: "array",
+                                                            items: { type: "object" },
+                                                        },
+                                                        tags: {
+                                                            type: "array",
+                                                            items: { type: "string" },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
-      },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word", { decode: true })!;
-  const { lang } = getQuery(event) as { lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const word = getRouterParam(event, "word", { decode: true })!;
+    const { lang } = getQuery(event) as { lang?: string };
 
-  const definitions = fetchWordEntries(edition, word, lang).map((r) => ({
-    pos: r.pos,
-    lang_code: r.lang_code,
-    senses: (JSON.parse(r.senses) as Record<string, unknown>[]).map((s) => ({
-      glosses: s.glosses ?? [],
-      examples: s.examples ?? [],
-      tags: s.tags ?? [],
-    })),
-  }));
+    const definitions = fetchWordEntries(edition, word, lang).map((r) => ({
+        pos: r.pos,
+        lang_code: r.lang_code,
+        senses: (JSON.parse(r.senses) as Record<string, unknown>[]).map((s) => ({
+            glosses: s.glosses ?? [],
+            examples: s.examples ?? [],
+            tags: s.tags ?? [],
+        })),
+    }));
 
-  return { word, edition, definitions };
+    return { word, edition, definitions };
 });

--- a/packages/api/routes/v1/[edition]/word/[word]/definitions.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/definitions.get.ts
@@ -73,7 +73,7 @@ defineRouteMeta({
 
 export default defineHandler((event) => {
   const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word")!;
+  const word = getRouterParam(event, "word", { decode: true })!;
   const { lang } = getQuery(event) as { lang?: string };
 
   const definitions = fetchWordEntries(edition, word, lang).map((r) => ({

--- a/packages/api/routes/v1/[edition]/word/[word]/forms.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/forms.get.ts
@@ -3,74 +3,74 @@ import { defineHandler, getRouterParam, getQuery } from "nitro/h3";
 import { fetchWordEntries } from "../../../../../utils/queries";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Word"],
-    summary: "Word forms",
-    description:
-      "Returns inflected forms (e.g. plural, genitive, conjugations) for each part-of-speech entry.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "path",
-        name: "word",
-        required: true,
-        schema: { type: "string" },
-        description: "The word to look up.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                word: { type: "string" },
-                edition: { type: "string" },
-                forms: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      pos: { type: "string" },
-                      lang_code: { type: "string" },
-                      forms: { type: "array", items: { type: "object" } },
-                    },
-                  },
-                },
-              },
+    openAPI: {
+        tags: ["Word"],
+        summary: "Word forms",
+        description:
+            "Returns inflected forms (e.g. plural, genitive, conjugations) for each part-of-speech entry.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "path",
+                name: "word",
+                required: true,
+                schema: { type: "string" },
+                description: "The word to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                word: { type: "string" },
+                                edition: { type: "string" },
+                                forms: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            pos: { type: "string" },
+                                            lang_code: { type: "string" },
+                                            forms: { type: "array", items: { type: "object" } },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
-      },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word", { decode: true })!;
-  const { lang } = getQuery(event) as { lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const word = getRouterParam(event, "word", { decode: true })!;
+    const { lang } = getQuery(event) as { lang?: string };
 
-  const forms = fetchWordEntries(edition, word, lang).map((r) => ({
-    pos: r.pos,
-    lang_code: r.lang_code,
-    forms: JSON.parse(r.forms ?? "[]"),
-  }));
+    const forms = fetchWordEntries(edition, word, lang).map((r) => ({
+        pos: r.pos,
+        lang_code: r.lang_code,
+        forms: JSON.parse(r.forms ?? "[]"),
+    }));
 
-  return { word, edition, forms };
+    return { word, edition, forms };
 });

--- a/packages/api/routes/v1/[edition]/word/[word]/forms.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/forms.get.ts
@@ -63,7 +63,7 @@ defineRouteMeta({
 
 export default defineHandler((event) => {
   const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word")!;
+  const word = getRouterParam(event, "word", { decode: true })!;
   const { lang } = getQuery(event) as { lang?: string };
 
   const forms = fetchWordEntries(edition, word, lang).map((r) => ({

--- a/packages/api/routes/v1/[edition]/word/[word]/pronunciations.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/pronunciations.get.ts
@@ -72,7 +72,7 @@ defineRouteMeta({
 
 export default defineHandler((event) => {
   const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word")!;
+  const word = getRouterParam(event, "word", { decode: true })!;
   const { lang } = getQuery(event) as { lang?: string };
 
   const pronunciations = fetchWordEntries(edition, word, lang).map((r) => ({

--- a/packages/api/routes/v1/[edition]/word/[word]/pronunciations.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/pronunciations.get.ts
@@ -3,87 +3,95 @@ import { defineHandler, getRouterParam, getQuery } from "nitro/h3";
 import { fetchWordEntries } from "../../../../../utils/queries";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Word"],
-    summary: "Word pronunciations",
-    description: "Returns IPA and audio pronunciations for each part-of-speech entry of the word.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "path",
-        name: "word",
-        required: true,
-        schema: { type: "string" },
-        description: "The word to look up.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                word: { type: "string" },
-                edition: { type: "string" },
-                pronunciations: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      pos: { type: "string" },
-                      lang_code: { type: "string" },
-                      sounds: {
-                        type: "array",
-                        items: {
-                          type: "object",
-                          properties: {
-                            ipa: { type: "string", nullable: true, example: "/haʊs/" },
-                            audio: { type: "string", nullable: true },
-                            tags: { type: "array", items: { type: "string" } },
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
+    openAPI: {
+        tags: ["Word"],
+        summary: "Word pronunciations",
+        description:
+            "Returns IPA and audio pronunciations for each part-of-speech entry of the word.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "path",
+                name: "word",
+                required: true,
+                schema: { type: "string" },
+                description: "The word to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                word: { type: "string" },
+                                edition: { type: "string" },
+                                pronunciations: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            pos: { type: "string" },
+                                            lang_code: { type: "string" },
+                                            sounds: {
+                                                type: "array",
+                                                items: {
+                                                    type: "object",
+                                                    properties: {
+                                                        ipa: {
+                                                            type: "string",
+                                                            nullable: true,
+                                                            example: "/haʊs/",
+                                                        },
+                                                        audio: { type: "string", nullable: true },
+                                                        tags: {
+                                                            type: "array",
+                                                            items: { type: "string" },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
-      },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word", { decode: true })!;
-  const { lang } = getQuery(event) as { lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const word = getRouterParam(event, "word", { decode: true })!;
+    const { lang } = getQuery(event) as { lang?: string };
 
-  const pronunciations = fetchWordEntries(edition, word, lang).map((r) => ({
-    pos: r.pos,
-    lang_code: r.lang_code,
-    sounds: (JSON.parse(r.sounds ?? "[]") as Record<string, unknown>[]).map((s) => ({
-      ipa: s.ipa ?? null,
-      audio: s.audio ?? null,
-      tags: s.tags ?? [],
-    })),
-  }));
+    const pronunciations = fetchWordEntries(edition, word, lang).map((r) => ({
+        pos: r.pos,
+        lang_code: r.lang_code,
+        sounds: (JSON.parse(r.sounds ?? "[]") as Record<string, unknown>[]).map((s) => ({
+            ipa: s.ipa ?? null,
+            audio: s.audio ?? null,
+            tags: s.tags ?? [],
+        })),
+    }));
 
-  return { word, edition, pronunciations };
+    return { word, edition, pronunciations };
 });

--- a/packages/api/routes/v1/[edition]/word/[word]/translations.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/translations.get.ts
@@ -3,73 +3,76 @@ import { defineHandler, getRouterParam, getQuery } from "nitro/h3";
 import { fetchWordEntries } from "../../../../../utils/queries";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Word"],
-    summary: "Word translations",
-    description: "Returns translation lists for each part-of-speech entry of the word.",
-    parameters: [
-      {
-        in: "path",
-        name: "edition",
-        required: true,
-        schema: { type: "string" },
-        description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
-      },
-      {
-        in: "path",
-        name: "word",
-        required: true,
-        schema: { type: "string" },
-        description: "The word to look up.",
-      },
-      {
-        in: "query",
-        name: "lang",
-        required: false,
-        schema: { type: "string" },
-        description: "Filter by language code (e.g. `de`, `ja`).",
-      },
-    ],
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                word: { type: "string" },
-                edition: { type: "string" },
-                translations: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      pos: { type: "string" },
-                      lang_code: { type: "string" },
-                      translations: { type: "array", items: { type: "object" } },
-                    },
-                  },
-                },
-              },
+    openAPI: {
+        tags: ["Word"],
+        summary: "Word translations",
+        description: "Returns translation lists for each part-of-speech entry of the word.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
             },
-          },
+            {
+                in: "path",
+                name: "word",
+                required: true,
+                schema: { type: "string" },
+                description: "The word to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                word: { type: "string" },
+                                edition: { type: "string" },
+                                translations: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            pos: { type: "string" },
+                                            lang_code: { type: "string" },
+                                            translations: {
+                                                type: "array",
+                                                items: { type: "object" },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
         },
-      },
     },
-  },
 });
 
 export default defineHandler((event) => {
-  const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word", { decode: true })!;
-  const { lang } = getQuery(event) as { lang?: string };
+    const edition = getRouterParam(event, "edition")!;
+    const word = getRouterParam(event, "word", { decode: true })!;
+    const { lang } = getQuery(event) as { lang?: string };
 
-  const translations = fetchWordEntries(edition, word, lang).map((r) => ({
-    pos: r.pos,
-    lang_code: r.lang_code,
-    translations: JSON.parse(r.translations ?? "[]"),
-  }));
+    const translations = fetchWordEntries(edition, word, lang).map((r) => ({
+        pos: r.pos,
+        lang_code: r.lang_code,
+        translations: JSON.parse(r.translations ?? "[]"),
+    }));
 
-  return { word, edition, translations };
+    return { word, edition, translations };
 });

--- a/packages/api/routes/v1/[edition]/word/[word]/translations.get.ts
+++ b/packages/api/routes/v1/[edition]/word/[word]/translations.get.ts
@@ -62,7 +62,7 @@ defineRouteMeta({
 
 export default defineHandler((event) => {
   const edition = getRouterParam(event, "edition")!;
-  const word = getRouterParam(event, "word")!;
+  const word = getRouterParam(event, "word", { decode: true })!;
   const { lang } = getQuery(event) as { lang?: string };
 
   const translations = fetchWordEntries(edition, word, lang).map((r) => ({

--- a/packages/api/routes/v1/[edition]/words.get.ts
+++ b/packages/api/routes/v1/[edition]/words.get.ts
@@ -1,0 +1,99 @@
+import { defineRouteMeta } from "nitro";
+import { defineHandler, getRouterParam, getQuery, createError } from "nitro/h3";
+import { fetchWordEntriesBatch } from "../../../utils/queries";
+
+defineRouteMeta({
+    openAPI: {
+        tags: ["Words"],
+        summary: "Batch word lookup",
+        description:
+            "Returns entries for multiple words in a single request. Words not found are included in the response with an error field.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
+            },
+            {
+                in: "query",
+                name: "words",
+                required: true,
+                schema: { type: "string" },
+                description: "Comma-separated list of words to look up.",
+            },
+            {
+                in: "query",
+                name: "lang",
+                required: false,
+                schema: { type: "string" },
+                description: "Filter by language code (e.g. `de`, `ja`).",
+            },
+        ],
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                results: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            word: { type: "string" },
+                                            entries: {
+                                                type: "array",
+                                                items: { type: "object" },
+                                                nullable: true,
+                                            },
+                                            error: { type: "string", nullable: true },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            400: { description: "Missing required query param `words`." },
+        },
+    },
+});
+
+export default defineHandler((event) => {
+    const edition = getRouterParam(event, "edition")!;
+    const { words, lang } = getQuery(event) as { words?: string; lang?: string };
+
+    if (!words) {
+        throw createError({ statusCode: 400, message: "Missing required query param: words" });
+    }
+
+    const wordList = words
+        .split(",")
+        .map((w) => w.trim())
+        .filter(Boolean);
+
+    if (wordList.length === 0) {
+        throw createError({ statusCode: 400, message: "No words provided" });
+    }
+
+    const results = fetchWordEntriesBatch(edition, wordList, lang);
+
+    return {
+        results: results.map((r) => ({
+            word: r.word,
+            entries:
+                r.entries?.map((entry) => ({
+                    senses: JSON.parse(entry.senses),
+                    sounds: JSON.parse(entry.sounds ?? "[]"),
+                    translations: JSON.parse(entry.translations ?? "[]"),
+                    forms: JSON.parse(entry.forms ?? "[]"),
+                })) ?? null,
+            error: r.entries === null ? "Word not found" : undefined,
+        })),
+    };
+});

--- a/packages/api/routes/v1/[edition]/words.post.ts
+++ b/packages/api/routes/v1/[edition]/words.post.ts
@@ -1,0 +1,104 @@
+import { defineRouteMeta } from "nitro";
+import { defineHandler, getRouterParam, createError, readBody } from "nitro/h3";
+import { fetchWordEntriesBatch } from "../../../utils/queries";
+
+defineRouteMeta({
+    openAPI: {
+        tags: ["Words"],
+        summary: "Batch word lookup (POST)",
+        description:
+            "Returns entries for multiple words in a single request. Words not found are included in the response with an error field.",
+        parameters: [
+            {
+                in: "path",
+                name: "edition",
+                required: true,
+                schema: { type: "string" },
+                description: "Wiktionary edition (e.g. `en`, `fr`, `de`).",
+            },
+        ],
+        requestBody: {
+            required: true,
+            content: {
+                "application/json": {
+                    schema: {
+                        type: "object",
+                        properties: {
+                            words: {
+                                type: "array",
+                                items: { type: "string" },
+                                description: "Array of words to look up.",
+                            },
+                            lang: {
+                                type: "string",
+                                description: "Filter by language code (e.g. `de`, `ja`).",
+                            },
+                        },
+                        required: ["words"],
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                results: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            word: { type: "string" },
+                                            entries: {
+                                                type: "array",
+                                                items: { type: "object" },
+                                                nullable: true,
+                                            },
+                                            error: { type: "string", nullable: true },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            400: { description: "Missing required field `words`." },
+        },
+    },
+});
+
+export default defineHandler(async (event) => {
+    const edition = getRouterParam(event, "edition")!;
+    const body = (await readBody(event)) as { words?: string[]; lang?: string } | null;
+
+    if (!body || !body.words) {
+        throw createError({ statusCode: 400, message: "Missing required field: words" });
+    }
+
+    const wordList = body.words.map((w) => w.trim()).filter(Boolean);
+
+    if (wordList.length === 0) {
+        throw createError({ statusCode: 400, message: "No words provided" });
+    }
+
+    const results = fetchWordEntriesBatch(edition, wordList, body.lang);
+
+    return {
+        results: results.map((r) => ({
+            word: r.word,
+            entries:
+                r.entries?.map((entry) => ({
+                    senses: JSON.parse(entry.senses),
+                    sounds: JSON.parse(entry.sounds ?? "[]"),
+                    translations: JSON.parse(entry.translations ?? "[]"),
+                    forms: JSON.parse(entry.forms ?? "[]"),
+                })) ?? null,
+            error: r.entries === null ? "Word not found" : undefined,
+        })),
+    };
+});

--- a/packages/api/routes/v1/editions.get.ts
+++ b/packages/api/routes/v1/editions.get.ts
@@ -3,33 +3,37 @@ import { defineHandler } from "nitro/h3";
 import { db } from "../../utils/db";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Meta"],
-    summary: "List editions",
-    description:
-      "Returns all Wiktionary editions available in the database (e.g. `en`, `fr`, `de`).",
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                editions: { type: "array", items: { type: "string" }, example: ["en", "fr", "de"] },
-              },
+    openAPI: {
+        tags: ["Meta"],
+        summary: "List editions",
+        description:
+            "Returns all Wiktionary editions available in the database (e.g. `en`, `fr`, `de`).",
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                editions: {
+                                    type: "array",
+                                    items: { type: "string" },
+                                    example: ["en", "fr", "de"],
+                                },
+                            },
+                        },
+                    },
+                },
             },
-          },
         },
-      },
     },
-  },
 });
 
 export default defineHandler(() => {
-  const rows = db.prepare("SELECT DISTINCT edition FROM entries ORDER BY edition").all() as {
-    edition: string;
-  }[];
+    const rows = db.prepare("SELECT DISTINCT edition FROM entries ORDER BY edition").all() as {
+        edition: string;
+    }[];
 
-  return { editions: rows.map((r) => r.edition) };
+    return { editions: rows.map((r) => r.edition) };
 });

--- a/packages/api/routes/v1/languages.get.ts
+++ b/packages/api/routes/v1/languages.get.ts
@@ -3,48 +3,52 @@ import { defineHandler } from "nitro/h3";
 import { db } from "../../utils/db";
 
 defineRouteMeta({
-  openAPI: {
-    tags: ["Meta"],
-    summary: "List languages",
-    description:
-      "Returns all languages present in the database with their entry counts, sorted by frequency.",
-    responses: {
-      200: {
-        description: "OK",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                languages: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      lang_code: { type: "string", example: "de" },
-                      lang: { type: "string", nullable: true, example: "German" },
-                      entry_count: { type: "integer", example: 42000 },
+    openAPI: {
+        tags: ["Meta"],
+        summary: "List languages",
+        description:
+            "Returns all languages present in the database with their entry counts, sorted by frequency.",
+        responses: {
+            200: {
+                description: "OK",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                languages: {
+                                    type: "array",
+                                    items: {
+                                        type: "object",
+                                        properties: {
+                                            lang_code: { type: "string", example: "de" },
+                                            lang: {
+                                                type: "string",
+                                                nullable: true,
+                                                example: "German",
+                                            },
+                                            entry_count: { type: "integer", example: 42000 },
+                                        },
+                                    },
+                                },
+                            },
+                        },
                     },
-                  },
                 },
-              },
             },
-          },
         },
-      },
     },
-  },
 });
 
 export default defineHandler(() => {
-  const rows = db
-    .prepare(
-      `SELECT lang_code, lang, COUNT(*) AS entry_count
+    const rows = db
+        .prepare(
+            `SELECT lang_code, lang, COUNT(*) AS entry_count
        FROM entries
        GROUP BY lang_code, lang
        ORDER BY entry_count DESC`,
-    )
-    .all() as { lang_code: string; lang: string | null; entry_count: number }[];
+        )
+        .all() as { lang_code: string; lang: string | null; entry_count: number }[];
 
-  return { languages: rows };
+    return { languages: rows };
 });

--- a/packages/api/scripts/build_indexes.ts
+++ b/packages/api/scripts/build_indexes.ts
@@ -15,35 +15,36 @@ const DATA_DIR = resolve("./data");
 const DEFAULT_DB_PATH = resolve(DATA_DIR, "wiktionary.db");
 
 function parseArgs(): { dbPath: string } {
-  const args = process.argv.slice(2);
-  const outputIdx = args.indexOf("--output");
-  return {
-    dbPath: outputIdx !== -1 ? resolve(args[outputIdx + 1] ?? DEFAULT_DB_PATH) : DEFAULT_DB_PATH,
-  };
+    const args = process.argv.slice(2);
+    const outputIdx = args.indexOf("--output");
+    return {
+        dbPath:
+            outputIdx !== -1 ? resolve(args[outputIdx + 1] ?? DEFAULT_DB_PATH) : DEFAULT_DB_PATH,
+    };
 }
 
 const main: Effect.Effect<void, Error> = Effect.gen(function* () {
-  const { dbPath } = parseArgs();
+    const { dbPath } = parseArgs();
 
-  const db = new Database(dbPath);
-  db.pragma("journal_mode = WAL");
-  db.pragma("synchronous = OFF");
-  db.pragma("cache_size = -65536"); // 64 MB
-  db.pragma("temp_store = MEMORY");
-  db.pragma("mmap_size = 268435456"); // 256 MB
+    const db = new Database(dbPath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("synchronous = OFF");
+    db.pragma("cache_size = -65536"); // 64 MB
+    db.pragma("temp_store = MEMORY");
+    db.pragma("mmap_size = 268435456"); // 256 MB
 
-  yield* Console.log(`Building indexes on ${dbPath} …`);
-  db.exec(ENTRIES_INDEXES_DDL);
+    yield* Console.log(`Building indexes on ${dbPath} …`);
+    db.exec(ENTRIES_INDEXES_DDL);
 
-  const { count } = db.prepare("SELECT COUNT(*) AS count FROM entries").get() as {
-    count: number;
-  };
-  yield* Console.log(`Done — ${count.toLocaleString()} total entries indexed`);
+    const { count } = db.prepare("SELECT COUNT(*) AS count FROM entries").get() as {
+        count: number;
+    };
+    yield* Console.log(`Done — ${count.toLocaleString()} total entries indexed`);
 
-  db.close();
+    db.close();
 });
 
 Effect.runPromise(main).catch((err) => {
-  console.error(err);
-  process.exit(1);
+    console.error(err);
+    process.exit(1);
 });

--- a/packages/api/scripts/download_kaikki.ts
+++ b/packages/api/scripts/download_kaikki.ts
@@ -23,133 +23,135 @@ const JSONL_DIR = resolve("./data/jsonl");
 
 // All editions available on kaikki.org/dictionary/rawdata.html
 const ALL_EDITIONS = [
-  "en",
-  "zh",
-  "cs",
-  "nl",
-  "fr",
-  "de",
-  "el",
-  "id",
-  "it",
-  "ja",
-  "ko",
-  "ku",
-  "ms",
-  "pl",
-  "pt",
-  "ru",
-  "simple",
-  "es",
-  "th",
-  "tr",
-  "vi",
+    "en",
+    "zh",
+    "cs",
+    "nl",
+    "fr",
+    "de",
+    "el",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "ku",
+    "ms",
+    "pl",
+    "pt",
+    "ru",
+    "simple",
+    "es",
+    "th",
+    "tr",
+    "vi",
 ];
 
 function kaikkiUrl(edition: string): string {
-  if (edition === "en") {
-    return "https://kaikki.org/dictionary/raw-wiktextract-data.jsonl.gz";
-  }
-  return `https://kaikki.org/dictionary/downloads/${edition}/${edition}-extract.jsonl.gz`;
+    if (edition === "en") {
+        return "https://kaikki.org/dictionary/raw-wiktextract-data.jsonl.gz";
+    }
+    return `https://kaikki.org/dictionary/downloads/${edition}/${edition}-extract.jsonl.gz`;
 }
 
 function parseArgs(): { editions: string[]; force: boolean } {
-  const args = process.argv.slice(2);
-  if (args.includes("--all")) {
-    return { editions: ALL_EDITIONS, force: args.includes("--force") };
-  }
-  const idx = args.indexOf("--editions");
-  const editionsList = idx !== -1 ? (args[idx + 1] ?? "en") : "en";
-  return {
-    editions: editionsList
-      .split(",")
-      .map((e) => e.trim())
-      .filter(Boolean),
-    force: args.includes("--force"),
-  };
+    const args = process.argv.slice(2);
+    if (args.includes("--all")) {
+        return { editions: ALL_EDITIONS, force: args.includes("--force") };
+    }
+    const idx = args.indexOf("--editions");
+    const editionsList = idx !== -1 ? (args[idx + 1] ?? "en") : "en";
+    return {
+        editions: editionsList
+            .split(",")
+            .map((e) => e.trim())
+            .filter(Boolean),
+        force: args.includes("--force"),
+    };
 }
 
 const fileExists = (path: string): Effect.Effect<boolean> =>
-  Effect.promise(() =>
-    access(path).then(
-      () => true,
-      () => false,
-    ),
-  );
+    Effect.promise(() =>
+        access(path).then(
+            () => true,
+            () => false,
+        ),
+    );
 
 const downloadEdition = (edition: string, force: boolean): Effect.Effect<void, Error> =>
-  Effect.gen(function* () {
-    const dest = resolve(JSONL_DIR, `${edition}.jsonl`);
-    const tmp = `${dest}.tmp`;
+    Effect.gen(function* () {
+        const dest = resolve(JSONL_DIR, `${edition}.jsonl`);
+        const tmp = `${dest}.tmp`;
 
-    if (!force && (yield* fileExists(dest))) {
-      yield* Console.log(`[${edition}] Already downloaded: ${dest}  (use --force to re-download)`);
-      return;
-    }
-
-    const url = kaikkiUrl(edition);
-    yield* Console.log(`[${edition}] Downloading ${url} …`);
-
-    const response = yield* Effect.tryPromise({
-      try: () => fetch(url),
-      catch: (e) => new Error(`Fetch failed: ${String(e)}`),
-    });
-
-    if (!response.ok || !response.body) {
-      return yield* Effect.fail(
-        new Error(`HTTP ${response.status} ${response.statusText} — ${url}`),
-      );
-    }
-
-    const total = Number(response.headers.get("content-length") ?? 0);
-    let downloaded = 0;
-
-    const progress = new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        downloaded += chunk.byteLength;
-        if (total) {
-          const pct = ((downloaded / total) * 100).toFixed(1);
-          const mb = (downloaded / 1_000_000).toFixed(0);
-          process.stdout.write(`\r  ${pct}%  (${mb} MB compressed)`);
+        if (!force && (yield* fileExists(dest))) {
+            yield* Console.log(
+                `[${edition}] Already downloaded: ${dest}  (use --force to re-download)`,
+            );
+            return;
         }
-        controller.enqueue(chunk);
-      },
+
+        const url = kaikkiUrl(edition);
+        yield* Console.log(`[${edition}] Downloading ${url} …`);
+
+        const response = yield* Effect.tryPromise({
+            try: () => fetch(url),
+            catch: (e) => new Error(`Fetch failed: ${String(e)}`),
+        });
+
+        if (!response.ok || !response.body) {
+            return yield* Effect.fail(
+                new Error(`HTTP ${response.status} ${response.statusText} — ${url}`),
+            );
+        }
+
+        const total = Number(response.headers.get("content-length") ?? 0);
+        let downloaded = 0;
+
+        const progress = new TransformStream<Uint8Array, Uint8Array>({
+            transform(chunk, controller) {
+                downloaded += chunk.byteLength;
+                if (total) {
+                    const pct = ((downloaded / total) * 100).toFixed(1);
+                    const mb = (downloaded / 1_000_000).toFixed(0);
+                    process.stdout.write(`\r  ${pct}%  (${mb} MB compressed)`);
+                }
+                controller.enqueue(chunk);
+            },
+        });
+
+        yield* Effect.tryPromise({
+            try: () =>
+                pipeline(
+                    Readable.fromWeb(response.body!.pipeThrough(progress) as any),
+                    createGunzip(),
+                    createWriteStream(tmp),
+                ),
+            catch: (e) => new Error(`Download pipeline failed: ${String(e)}`),
+        }).pipe(Effect.tapError(() => Effect.promise(() => unlink(tmp).catch(() => {}))));
+
+        process.stdout.write("\n");
+
+        yield* Effect.tryPromise({
+            try: () => rename(tmp, dest),
+            catch: (e) => new Error(`Failed to rename temp file: ${String(e)}`),
+        });
+
+        yield* Console.log(`[${edition}] Saved to ${dest}`);
     });
-
-    yield* Effect.tryPromise({
-      try: () =>
-        pipeline(
-          Readable.fromWeb(response.body!.pipeThrough(progress) as any),
-          createGunzip(),
-          createWriteStream(tmp),
-        ),
-      catch: (e) => new Error(`Download pipeline failed: ${String(e)}`),
-    }).pipe(Effect.tapError(() => Effect.promise(() => unlink(tmp).catch(() => {}))));
-
-    process.stdout.write("\n");
-
-    yield* Effect.tryPromise({
-      try: () => rename(tmp, dest),
-      catch: (e) => new Error(`Failed to rename temp file: ${String(e)}`),
-    });
-
-    yield* Console.log(`[${edition}] Saved to ${dest}`);
-  });
 
 const main: Effect.Effect<void, Error> = Effect.gen(function* () {
-  const { editions, force } = parseArgs();
+    const { editions, force } = parseArgs();
 
-  yield* Effect.tryPromise({
-    try: () => mkdir(JSONL_DIR, { recursive: true }),
-    catch: (e) => new Error(`Failed to create directory: ${String(e)}`),
-  });
+    yield* Effect.tryPromise({
+        try: () => mkdir(JSONL_DIR, { recursive: true }),
+        catch: (e) => new Error(`Failed to create directory: ${String(e)}`),
+    });
 
-  yield* Effect.forEach(editions, (edition) => downloadEdition(edition, force), {
-    concurrency: 5,
-  });
+    yield* Effect.forEach(editions, (edition) => downloadEdition(edition, force), {
+        concurrency: 5,
+    });
 });
 
 Effect.runPromise(main).catch((err) => {
-  console.error(err);
-  process.exit(1);
+    console.error(err);
+    process.exit(1);
 });

--- a/packages/api/scripts/import_data.ts
+++ b/packages/api/scripts/import_data.ts
@@ -25,221 +25,228 @@ const BATCH_SIZE = 50_000;
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface EntryRow {
-  word: string;
-  lang_code: string;
-  lang: string | null;
-  edition: string;
-  pos: string | null;
-  senses: string;
-  sounds: string | null;
-  translations: string | null;
-  forms: string | null;
+    word: string;
+    lang_code: string;
+    lang: string | null;
+    edition: string;
+    pos: string | null;
+    senses: string;
+    sounds: string | null;
+    translations: string | null;
+    forms: string | null;
 }
 
 // ── Database setup ───────────────────────────────────────────────────────────
 
 const makeDatabase = (dbPath: string, fresh: boolean) =>
-  Effect.acquireRelease(
-    Effect.try({
-      try: () => {
-        const db = new Database(dbPath);
-        db.pragma("journal_mode = WAL");
-        db.pragma("synchronous = OFF");
-        db.pragma("cache_size = -65536"); // 64 MB
-        db.pragma("temp_store = MEMORY");
-        db.pragma("mmap_size = 268435456"); // 256 MB
+    Effect.acquireRelease(
+        Effect.try({
+            try: () => {
+                const db = new Database(dbPath);
+                db.pragma("journal_mode = WAL");
+                db.pragma("synchronous = OFF");
+                db.pragma("cache_size = -65536"); // 64 MB
+                db.pragma("temp_store = MEMORY");
+                db.pragma("mmap_size = 268435456"); // 256 MB
 
-        if (fresh) db.exec("DROP TABLE IF EXISTS entries");
+                if (fresh) db.exec("DROP TABLE IF EXISTS entries");
 
-        db.exec(ENTRIES_TABLE_DDL);
+                db.exec(ENTRIES_TABLE_DDL);
 
-        return db;
-      },
-      catch: (e) => new Error(`Failed to open database: ${String(e)}`),
-    }),
-    (db) => Effect.sync(() => db.close()),
-  );
+                return db;
+            },
+            catch: (e) => new Error(`Failed to open database: ${String(e)}`),
+        }),
+        (db) => Effect.sync(() => db.close()),
+    );
 
 // ── Parsing ───────────────────────────────────────────────────────────────────
 
 function parseEntry(line: string, edition: string): EntryRow | null {
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = JSON.parse(line);
-  } catch {
-    return null;
-  }
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(line);
+    } catch {
+        return null;
+    }
 
-  const word = parsed.word as string | undefined;
-  const lang_code = parsed.lang_code as string | undefined;
-  if (!word || !lang_code) return null;
+    const word = parsed.word as string | undefined;
+    const lang_code = parsed.lang_code as string | undefined;
+    if (!word || !lang_code) return null;
 
-  const toJsonOrNull = (val: unknown) => {
-    const arr = (val as unknown[]) ?? [];
-    return arr.length ? JSON.stringify(arr) : null;
-  };
+    const toJsonOrNull = (val: unknown) => {
+        const arr = (val as unknown[]) ?? [];
+        return arr.length ? JSON.stringify(arr) : null;
+    };
 
-  return {
-    word,
-    lang_code,
-    lang: (parsed.lang as string | null) ?? null,
-    edition,
-    pos: (parsed.pos as string | null) ?? null,
-    senses: JSON.stringify(parsed.senses ?? []),
-    sounds: toJsonOrNull(parsed.sounds),
-    translations: toJsonOrNull(parsed.translations),
-    forms: toJsonOrNull(parsed.forms),
-  };
+    return {
+        word,
+        lang_code,
+        lang: (parsed.lang as string | null) ?? null,
+        edition,
+        pos: (parsed.pos as string | null) ?? null,
+        senses: JSON.stringify(parsed.senses ?? []),
+        sounds: toJsonOrNull(parsed.sounds),
+        translations: toJsonOrNull(parsed.translations),
+        forms: toJsonOrNull(parsed.forms),
+    };
 }
 
 // ── Import ───────────────────────────────────────────────────────────────────
 
 const importJsonl = (
-  db: Database.Database,
-  filePath: string,
-  edition: string,
+    db: Database.Database,
+    filePath: string,
+    edition: string,
 ): Effect.Effect<void, Error> =>
-  Effect.gen(function* () {
-    yield* Console.log(`[${edition}] Importing ${filePath} …`);
+    Effect.gen(function* () {
+        yield* Console.log(`[${edition}] Importing ${filePath} …`);
 
-    const insert = db.prepare(ENTRIES_INSERT_SQL);
+        const insert = db.prepare(ENTRIES_INSERT_SQL);
 
-    const insertMany = db.transaction((rows: EntryRow[]) => {
-      for (const row of rows) insert.run(row);
-    });
-
-    const { count, skipped } = yield* Effect.tryPromise({
-      try: async () => {
-        const rl = createInterface({
-          input: createReadStream(filePath, { encoding: "utf-8" }),
-          crlfDelay: Infinity,
+        const insertMany = db.transaction((rows: EntryRow[]) => {
+            for (const row of rows) insert.run(row);
         });
 
-        let count = 0;
-        let skipped = 0;
-        const batch: EntryRow[] = [];
+        const { count, skipped } = yield* Effect.tryPromise({
+            try: async () => {
+                const rl = createInterface({
+                    input: createReadStream(filePath, { encoding: "utf-8" }),
+                    crlfDelay: Infinity,
+                });
 
-        try {
-          for await (const line of rl) {
-            if (!line.trim()) continue;
+                let count = 0;
+                let skipped = 0;
+                const batch: EntryRow[] = [];
 
-            const row = parseEntry(line, edition);
-            if (!row) {
-              skipped++;
-              continue;
-            }
+                try {
+                    for await (const line of rl) {
+                        if (!line.trim()) continue;
 
-            batch.push(row);
+                        const row = parseEntry(line, edition);
+                        if (!row) {
+                            skipped++;
+                            continue;
+                        }
 
-            if (batch.length >= BATCH_SIZE) {
-              insertMany(batch);
-              count += batch.length;
-              batch.length = 0;
-              if (count % 50_000 === 0) {
-                process.stdout.write(`  ${count.toLocaleString()} rows inserted …\r`);
-              }
-            }
-          }
-        } finally {
-          rl.close();
-        }
+                        batch.push(row);
 
-        if (batch.length > 0) {
-          insertMany(batch);
-          count += batch.length;
-        }
+                        if (batch.length >= BATCH_SIZE) {
+                            insertMany(batch);
+                            count += batch.length;
+                            batch.length = 0;
+                            if (count % 50_000 === 0) {
+                                process.stdout.write(
+                                    `  ${count.toLocaleString()} rows inserted …\r`,
+                                );
+                            }
+                        }
+                    }
+                } finally {
+                    rl.close();
+                }
 
-        return { count, skipped };
-      },
-      catch: (e) => new Error(`Failed to import ${filePath}: ${String(e)}`),
+                if (batch.length > 0) {
+                    insertMany(batch);
+                    count += batch.length;
+                }
+
+                return { count, skipped };
+            },
+            catch: (e) => new Error(`Failed to import ${filePath}: ${String(e)}`),
+        });
+
+        yield* Console.log(
+            `[${edition}] Done — ${count.toLocaleString()} rows inserted, ${skipped} skipped`,
+        );
     });
-
-    yield* Console.log(
-      `[${edition}] Done — ${count.toLocaleString()} rows inserted, ${skipped} skipped`,
-    );
-  });
 
 // ── Arg parsing ───────────────────────────────────────────────────────────────
 
 function parseArgs(): {
-  targetEdition: string | null;
-  fresh: boolean;
-  dbPath: string;
-  skipIndexes: boolean;
+    targetEdition: string | null;
+    fresh: boolean;
+    dbPath: string;
+    skipIndexes: boolean;
 } {
-  const args = process.argv.slice(2);
-  const editionIdx = args.indexOf("--edition");
-  const outputIdx = args.indexOf("--output");
-  return {
-    targetEdition: editionIdx !== -1 ? (args[editionIdx + 1] ?? null) : null,
-    fresh: args.includes("--fresh"),
-    skipIndexes: args.includes("--skip-indexes"),
-    dbPath: outputIdx !== -1 ? resolve(args[outputIdx + 1] ?? DEFAULT_DB_PATH) : DEFAULT_DB_PATH,
-  };
+    const args = process.argv.slice(2);
+    const editionIdx = args.indexOf("--edition");
+    const outputIdx = args.indexOf("--output");
+    return {
+        targetEdition: editionIdx !== -1 ? (args[editionIdx + 1] ?? null) : null,
+        fresh: args.includes("--fresh"),
+        skipIndexes: args.includes("--skip-indexes"),
+        dbPath:
+            outputIdx !== -1 ? resolve(args[outputIdx + 1] ?? DEFAULT_DB_PATH) : DEFAULT_DB_PATH,
+    };
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 const main: Effect.Effect<void, Error> = Effect.scoped(
-  Effect.gen(function* () {
-    const { targetEdition, fresh, dbPath, skipIndexes } = parseArgs();
+    Effect.gen(function* () {
+        const { targetEdition, fresh, dbPath, skipIndexes } = parseArgs();
 
-    if (fresh) yield* Console.log("--fresh: dropping existing entries table …");
+        if (fresh) yield* Console.log("--fresh: dropping existing entries table …");
 
-    const db = yield* makeDatabase(dbPath, fresh);
+        const db = yield* makeDatabase(dbPath, fresh);
 
-    let files: { path: string; edition: string }[];
+        let files: { path: string; edition: string }[];
 
-    if (targetEdition) {
-      files = [{ path: resolve(JSONL_DIR, `${targetEdition}.jsonl`), edition: targetEdition }];
-    } else {
-      const entries = yield* Effect.tryPromise({
-        try: () => readdir(JSONL_DIR),
-        catch: (e) => new Error(`Failed to read JSONL directory: ${String(e)}`),
-      });
-      files = entries
-        .filter((f) => f.endsWith(".jsonl"))
-        .map((f) => ({ path: resolve(JSONL_DIR, f), edition: f.replace(/\.jsonl$/, "") }));
-    }
+        if (targetEdition) {
+            files = [
+                { path: resolve(JSONL_DIR, `${targetEdition}.jsonl`), edition: targetEdition },
+            ];
+        } else {
+            const entries = yield* Effect.tryPromise({
+                try: () => readdir(JSONL_DIR),
+                catch: (e) => new Error(`Failed to read JSONL directory: ${String(e)}`),
+            });
+            files = entries
+                .filter((f) => f.endsWith(".jsonl"))
+                .map((f) => ({ path: resolve(JSONL_DIR, f), edition: f.replace(/\.jsonl$/, "") }));
+        }
 
-    if (files.length === 0) {
-      yield* Effect.fail(
-        new Error("No JSONL files found. Run `vp run @wiktapi/api#download` first."),
-      );
-    }
+        if (files.length === 0) {
+            yield* Effect.fail(
+                new Error("No JSONL files found. Run `vp run @wiktapi/api#download` first."),
+            );
+        }
 
-    yield* Effect.forEach(
-      files,
-      ({ path, edition }) =>
-        Effect.gen(function* () {
-          yield* importJsonl(db, path, edition);
-          yield* Effect.tryPromise({
-            try: () => unlink(path),
-            catch: (e) => new Error(`Failed to delete ${path}: ${String(e)}`),
-          });
-          yield* Console.log(`[${edition}] Deleted ${path}`);
-        }),
-      { concurrency: 1 },
-    );
+        yield* Effect.forEach(
+            files,
+            ({ path, edition }) =>
+                Effect.gen(function* () {
+                    yield* importJsonl(db, path, edition);
+                    yield* Effect.tryPromise({
+                        try: () => unlink(path),
+                        catch: (e) => new Error(`Failed to delete ${path}: ${String(e)}`),
+                    });
+                    yield* Console.log(`[${edition}] Deleted ${path}`);
+                }),
+            { concurrency: 1 },
+        );
 
-    if (skipIndexes) {
-      yield* Console.log("\nSkipping indexes (run `vp run @wiktapi/api#index` separately).");
-    } else {
-      yield* Console.log("\nBuilding indexes …");
-      db.exec(ENTRIES_INDEXES_DDL);
-    }
+        if (skipIndexes) {
+            yield* Console.log("\nSkipping indexes (run `vp run @wiktapi/api#index` separately).");
+        } else {
+            yield* Console.log("\nBuilding indexes …");
+            db.exec(ENTRIES_INDEXES_DDL);
+        }
 
-    const { count } = db.prepare("SELECT COUNT(*) AS count FROM entries").get() as {
-      count: number;
-    };
-    yield* Console.log(`\nDatabase ready at ${dbPath} — ${count.toLocaleString()} total entries`);
-    yield* Console.log(
-      "\nReminder: purge the Cloudflare cache so clients get fresh data (dashboard → Caching → Purge Everything).",
-    );
-  }),
+        const { count } = db.prepare("SELECT COUNT(*) AS count FROM entries").get() as {
+            count: number;
+        };
+        yield* Console.log(
+            `\nDatabase ready at ${dbPath} — ${count.toLocaleString()} total entries`,
+        );
+        yield* Console.log(
+            "\nReminder: purge the Cloudflare cache so clients get fresh data (dashboard → Caching → Purge Everything).",
+        );
+    }),
 );
 
 Effect.runPromise(main).catch((err) => {
-  console.error(err);
-  process.exit(1);
+    console.error(err);
+    process.exit(1);
 });

--- a/packages/api/scripts/test.ts
+++ b/packages/api/scripts/test.ts
@@ -1,0 +1,22 @@
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+
+const stream = createReadStream("../data/jsonl/cs.jsonl", { encoding: "utf8" });
+
+const rl = createInterface({
+    input: stream,
+    crlfDelay: Infinity,
+});
+
+for await (const line of rl) {
+    if (!line.trim()) {
+        continue;
+    }
+
+    const obj = JSON.parse(line);
+
+    if (obj["word"] === "placka") {
+        console.log(line);
+        break;
+    }
+}

--- a/packages/api/tests/global-setup.ts
+++ b/packages/api/tests/global-setup.ts
@@ -8,88 +8,90 @@ const dir = dirname(fileURLToPath(import.meta.url));
 export const TEST_DB_PATH = resolve(dir, "../data/test.db");
 
 const SAMPLE_ENTRIES = [
-  {
-    word: "chat",
-    lang_code: "fr",
-    lang: "French",
-    edition: "en",
-    pos: "noun",
-    senses: JSON.stringify([{ glosses: ["cat"], examples: [{ text: "Le chat dort." }], tags: [] }]),
-    sounds: JSON.stringify([{ ipa: "/ʃa/", audio: null, tags: [] }]),
-    translations: null,
-    forms: JSON.stringify([{ form: "chats", tags: ["plural"] }]),
-  },
-  {
-    word: "Haus",
-    lang_code: "de",
-    lang: "German",
-    edition: "en",
-    pos: "noun",
-    senses: JSON.stringify([{ glosses: ["house", "building"], examples: [], tags: [] }]),
-    sounds: JSON.stringify([{ ipa: "/haʊ̯s/", audio: null, tags: [] }]),
-    translations: null,
-    forms: JSON.stringify([
-      { form: "Hauses", tags: ["genitive", "singular"] },
-      { form: "Häuser", tags: ["plural"] },
-    ]),
-  },
-  {
-    word: "run",
-    lang_code: "en",
-    lang: "English",
-    edition: "en",
-    pos: "noun",
-    senses: JSON.stringify([{ glosses: ["act of running"], examples: [], tags: [] }]),
-    sounds: JSON.stringify([{ ipa: "/ɹʌn/", audio: null, tags: [] }]),
-    translations: null,
-    forms: null,
-  },
-  {
-    word: "run",
-    lang_code: "en",
-    lang: "English",
-    edition: "en",
-    pos: "verb",
-    senses: JSON.stringify([
-      {
-        glosses: ["to move quickly on foot"],
-        examples: [{ text: "I run every day." }],
-        tags: [],
-      },
-    ]),
-    sounds: JSON.stringify([{ ipa: "/ɹʌn/", audio: null, tags: [] }]),
-    translations: JSON.stringify([{ lang: "French", lang_code: "fr", word: "courir" }]),
-    forms: JSON.stringify([{ form: "ran", tags: ["past"] }]),
-  },
-  {
-    word: "chat",
-    lang_code: "fr",
-    lang: "French",
-    edition: "fr",
-    pos: "noun",
-    senses: JSON.stringify([{ glosses: ["chat domestique"], examples: [], tags: [] }]),
-    sounds: JSON.stringify([{ ipa: "/ʃa/", audio: null, tags: [] }]),
-    translations: JSON.stringify([{ lang: "English", lang_code: "en", word: "cat" }]),
-    forms: JSON.stringify([{ form: "chats", tags: ["plural"] }]),
-  },
+    {
+        word: "chat",
+        lang_code: "fr",
+        lang: "French",
+        edition: "en",
+        pos: "noun",
+        senses: JSON.stringify([
+            { glosses: ["cat"], examples: [{ text: "Le chat dort." }], tags: [] },
+        ]),
+        sounds: JSON.stringify([{ ipa: "/ʃa/", audio: null, tags: [] }]),
+        translations: null,
+        forms: JSON.stringify([{ form: "chats", tags: ["plural"] }]),
+    },
+    {
+        word: "Haus",
+        lang_code: "de",
+        lang: "German",
+        edition: "en",
+        pos: "noun",
+        senses: JSON.stringify([{ glosses: ["house", "building"], examples: [], tags: [] }]),
+        sounds: JSON.stringify([{ ipa: "/haʊ̯s/", audio: null, tags: [] }]),
+        translations: null,
+        forms: JSON.stringify([
+            { form: "Hauses", tags: ["genitive", "singular"] },
+            { form: "Häuser", tags: ["plural"] },
+        ]),
+    },
+    {
+        word: "run",
+        lang_code: "en",
+        lang: "English",
+        edition: "en",
+        pos: "noun",
+        senses: JSON.stringify([{ glosses: ["act of running"], examples: [], tags: [] }]),
+        sounds: JSON.stringify([{ ipa: "/ɹʌn/", audio: null, tags: [] }]),
+        translations: null,
+        forms: null,
+    },
+    {
+        word: "run",
+        lang_code: "en",
+        lang: "English",
+        edition: "en",
+        pos: "verb",
+        senses: JSON.stringify([
+            {
+                glosses: ["to move quickly on foot"],
+                examples: [{ text: "I run every day." }],
+                tags: [],
+            },
+        ]),
+        sounds: JSON.stringify([{ ipa: "/ɹʌn/", audio: null, tags: [] }]),
+        translations: JSON.stringify([{ lang: "French", lang_code: "fr", word: "courir" }]),
+        forms: JSON.stringify([{ form: "ran", tags: ["past"] }]),
+    },
+    {
+        word: "chat",
+        lang_code: "fr",
+        lang: "French",
+        edition: "fr",
+        pos: "noun",
+        senses: JSON.stringify([{ glosses: ["chat domestique"], examples: [], tags: [] }]),
+        sounds: JSON.stringify([{ ipa: "/ʃa/", audio: null, tags: [] }]),
+        translations: JSON.stringify([{ lang: "English", lang_code: "en", word: "cat" }]),
+        forms: JSON.stringify([{ form: "chats", tags: ["plural"] }]),
+    },
 ];
 
 export function setup() {
-  mkdirSync(resolve(dir, "../data"), { recursive: true });
+    mkdirSync(resolve(dir, "../data"), { recursive: true });
 
-  const db = new Database(TEST_DB_PATH);
-  db.exec(ENTRIES_TABLE_DDL);
-  db.exec(ENTRIES_INDEXES_DDL);
+    const db = new Database(TEST_DB_PATH);
+    db.exec(ENTRIES_TABLE_DDL);
+    db.exec(ENTRIES_INDEXES_DDL);
 
-  const insert = db.prepare(ENTRIES_INSERT_SQL);
-  const insertMany = db.transaction((rows: typeof SAMPLE_ENTRIES) => {
-    for (const row of rows) insert.run(row);
-  });
+    const insert = db.prepare(ENTRIES_INSERT_SQL);
+    const insertMany = db.transaction((rows: typeof SAMPLE_ENTRIES) => {
+        for (const row of rows) insert.run(row);
+    });
 
-  insertMany(SAMPLE_ENTRIES);
-  db.close();
+    insertMany(SAMPLE_ENTRIES);
+    db.close();
 }
 
 export function teardown() {
-  rmSync(TEST_DB_PATH, { force: true });
+    rmSync(TEST_DB_PATH, { force: true });
 }

--- a/packages/api/tests/helpers/event.ts
+++ b/packages/api/tests/helpers/event.ts
@@ -5,14 +5,14 @@ import { mockEvent } from "nitro/h3";
  * Uses h3 v2's built-in mockEvent under the hood.
  */
 export function createTestEvent(
-  params: Record<string, string> = {},
-  query: Record<string, string> = {},
+    params: Record<string, string> = {},
+    query: Record<string, string> = {},
 ) {
-  const qs = new URLSearchParams(query).toString();
-  const url = qs ? `/?${qs}` : "/";
-  const event = mockEvent(url);
-  event.context.params = params;
-  return event;
+    const qs = new URLSearchParams(query).toString();
+    const url = qs ? `/?${qs}` : "/";
+    const event = mockEvent(url);
+    event.context.params = params;
+    return event;
 }
 
 /**
@@ -20,8 +20,8 @@ export function createTestEvent(
  * so that Vitest's `rejects` matchers work correctly.
  */
 export function call(
-  handler: (e: ReturnType<typeof mockEvent>) => unknown,
-  event: ReturnType<typeof mockEvent>,
+    handler: (e: ReturnType<typeof mockEvent>) => unknown,
+    event: ReturnType<typeof mockEvent>,
 ) {
-  return Promise.resolve().then(() => handler(event));
+    return Promise.resolve().then(() => handler(event));
 }

--- a/packages/api/tests/routes/metadata.test.ts
+++ b/packages/api/tests/routes/metadata.test.ts
@@ -4,35 +4,35 @@ import editionsHandler from "../../routes/v1/editions.get";
 import languagesHandler from "../../routes/v1/languages.get";
 
 describe("GET /v1/editions", () => {
-  it("returns all distinct editions", () => {
-    const result = editionsHandler(createTestEvent());
-    expect(result).toEqual({ editions: ["en", "fr"] });
-  });
+    it("returns all distinct editions", () => {
+        const result = editionsHandler(createTestEvent());
+        expect(result).toEqual({ editions: ["en", "fr"] });
+    });
 });
 
 describe("GET /v1/languages", () => {
-  it("returns all languages with entry counts", () => {
-    const result = languagesHandler(createTestEvent());
-    expect(result.languages.length).toBeGreaterThan(0);
+    it("returns all languages with entry counts", () => {
+        const result = languagesHandler(createTestEvent());
+        expect(result.languages.length).toBeGreaterThan(0);
 
-    const codes = result.languages.map((l: { lang_code: string }) => l.lang_code);
-    expect(codes).toContain("fr");
-    expect(codes).toContain("de");
-    expect(codes).toContain("en");
-  });
+        const codes = result.languages.map((l: { lang_code: string }) => l.lang_code);
+        expect(codes).toContain("fr");
+        expect(codes).toContain("de");
+        expect(codes).toContain("en");
+    });
 
-  it("includes entry_count for each language", () => {
-    const result = languagesHandler(createTestEvent());
-    for (const lang of result.languages) {
-      expect(lang.entry_count).toBeGreaterThan(0);
-    }
-  });
+    it("includes entry_count for each language", () => {
+        const result = languagesHandler(createTestEvent());
+        for (const lang of result.languages) {
+            expect(lang.entry_count).toBeGreaterThan(0);
+        }
+    });
 
-  it("is sorted by entry count descending", () => {
-    const result = languagesHandler(createTestEvent());
-    const counts = result.languages.map((l: { entry_count: number }) => l.entry_count);
-    for (let i = 1; i < counts.length; i++) {
-      expect(counts[i]).toBeLessThanOrEqual(counts[i - 1]!);
-    }
-  });
+    it("is sorted by entry count descending", () => {
+        const result = languagesHandler(createTestEvent());
+        const counts = result.languages.map((l: { entry_count: number }) => l.entry_count);
+        for (let i = 1; i < counts.length; i++) {
+            expect(counts[i]).toBeLessThanOrEqual(counts[i - 1]!);
+        }
+    });
 });

--- a/packages/api/tests/routes/search.test.ts
+++ b/packages/api/tests/routes/search.test.ts
@@ -3,46 +3,48 @@ import { createTestEvent, call } from "../helpers/event.ts";
 import searchHandler from "../../routes/v1/[edition]/search.get";
 
 describe("GET /v1/{edition}/search", () => {
-  it("returns prefix matches", async () => {
-    const event = createTestEvent({ edition: "en" }, { q: "ch" });
-    const result = searchHandler(event);
+    it("returns prefix matches", async () => {
+        const event = createTestEvent({ edition: "en" }, { q: "ch" });
+        const result = searchHandler(event);
 
-    const words = result.results.map((r: { word: string }) => r.word);
-    expect(words).toContain("chat");
-  });
+        const words = result.results.map((r: { word: string }) => r.word);
+        expect(words).toContain("chat");
+    });
 
-  it("filters by lang when ?lang= is provided", async () => {
-    const event = createTestEvent({ edition: "en" }, { q: "ch", lang: "fr" });
-    const result = searchHandler(event);
+    it("filters by lang when ?lang= is provided", async () => {
+        const event = createTestEvent({ edition: "en" }, { q: "ch", lang: "fr" });
+        const result = searchHandler(event);
 
-    expect(result.results.every((r: { lang_code: string }) => r.lang_code === "fr")).toBe(true);
-  });
+        expect(result.results.every((r: { lang_code: string }) => r.lang_code === "fr")).toBe(true);
+    });
 
-  it("returns 400 when q is missing", async () => {
-    const event = createTestEvent({ edition: "en" });
-    await expect(call(searchHandler, event)).rejects.toSatisfy((e: any) => e.statusCode === 400);
-  });
+    it("returns 400 when q is missing", async () => {
+        const event = createTestEvent({ edition: "en" });
+        await expect(call(searchHandler, event)).rejects.toSatisfy(
+            (e: any) => e.statusCode === 400,
+        );
+    });
 
-  it("returns empty results for no match", async () => {
-    const event = createTestEvent({ edition: "en" }, { q: "xyzxyz" });
-    const result = searchHandler(event);
+    it("returns empty results for no match", async () => {
+        const event = createTestEvent({ edition: "en" }, { q: "xyzxyz" });
+        const result = searchHandler(event);
 
-    expect(result.results).toHaveLength(0);
-  });
+        expect(result.results).toHaveLength(0);
+    });
 
-  it("is case-insensitive", async () => {
-    const event = createTestEvent({ edition: "en" }, { q: "CHAT" });
-    const result = searchHandler(event);
+    it("is case-insensitive", async () => {
+        const event = createTestEvent({ edition: "en" }, { q: "CHAT" });
+        const result = searchHandler(event);
 
-    const words = result.results.map((r: { word: string }) => r.word);
-    expect(words).toContain("chat");
-  });
+        const words = result.results.map((r: { word: string }) => r.word);
+        expect(words).toContain("chat");
+    });
 
-  it("only returns results for the requested edition", async () => {
-    const event = createTestEvent({ edition: "fr" }, { q: "ch" });
-    const result = searchHandler(event);
+    it("only returns results for the requested edition", async () => {
+        const event = createTestEvent({ edition: "fr" }, { q: "ch" });
+        const result = searchHandler(event);
 
-    // "chat" exists in fr edition but with fr lang_code
-    expect(result.results.length).toBeGreaterThan(0);
-  });
+        // "chat" exists in fr edition but with fr lang_code
+        expect(result.results.length).toBeGreaterThan(0);
+    });
 });

--- a/packages/api/tests/routes/word.test.ts
+++ b/packages/api/tests/routes/word.test.ts
@@ -9,111 +9,111 @@ import formsHandler from "../../routes/v1/[edition]/word/[word]/forms.get";
 // ── /word/{word} ─────────────────────────────────────────────────────────────
 
 describe("GET /v1/{edition}/word/{word}", () => {
-  it("returns all entries for a word across languages", async () => {
-    const event = createTestEvent({ edition: "en", word: "run" });
-    const result = wordHandler(event);
+    it("returns all entries for a word across languages", async () => {
+        const event = createTestEvent({ edition: "en", word: "run" });
+        const result = wordHandler(event);
 
-    expect(result.word).toBe("run");
-    expect(result.edition).toBe("en");
-    expect(result.entries).toHaveLength(2); // noun + verb
-  });
+        expect(result.word).toBe("run");
+        expect(result.edition).toBe("en");
+        expect(result.entries).toHaveLength(2); // noun + verb
+    });
 
-  it("filters by lang when ?lang= is provided", async () => {
-    const event = createTestEvent({ edition: "en", word: "chat" }, { lang: "fr" });
-    const result = wordHandler(event);
+    it("filters by lang when ?lang= is provided", async () => {
+        const event = createTestEvent({ edition: "en", word: "chat" }, { lang: "fr" });
+        const result = wordHandler(event);
 
-    expect(result.entries).toHaveLength(1);
-    expect(result.entries[0]?.senses[0]?.glosses).toContain("cat");
-  });
+        expect(result.entries).toHaveLength(1);
+        expect(result.entries[0]?.senses[0]?.glosses).toContain("cat");
+    });
 
-  it("returns 404 for unknown word", async () => {
-    const event = createTestEvent({ edition: "en", word: "xyzunknown" });
-    await expect(call(wordHandler, event)).rejects.toSatisfy((e: any) => e.statusCode === 404);
-  });
+    it("returns 404 for unknown word", async () => {
+        const event = createTestEvent({ edition: "en", word: "xyzunknown" });
+        await expect(call(wordHandler, event)).rejects.toSatisfy((e: any) => e.statusCode === 404);
+    });
 
-  it("returns 404 for wrong edition", async () => {
-    const event = createTestEvent({ edition: "de", word: "chat" });
-    await expect(call(wordHandler, event)).rejects.toSatisfy((e: any) => e.statusCode === 404);
-  });
+    it("returns 404 for wrong edition", async () => {
+        const event = createTestEvent({ edition: "de", word: "chat" });
+        await expect(call(wordHandler, event)).rejects.toSatisfy((e: any) => e.statusCode === 404);
+    });
 });
 
 // ── /word/{word}/definitions ──────────────────────────────────────────────────
 
 describe("GET /v1/{edition}/word/{word}/definitions", () => {
-  it("returns senses with glosses", async () => {
-    const event = createTestEvent({ edition: "en", word: "Haus" });
-    const result = definitionsHandler(event);
+    it("returns senses with glosses", async () => {
+        const event = createTestEvent({ edition: "en", word: "Haus" });
+        const result = definitionsHandler(event);
 
-    expect(result.definitions).toHaveLength(1);
-    expect(result.definitions[0]?.pos).toBe("noun");
-    expect(result.definitions[0]?.senses[0]?.glosses).toContain("house");
-  });
+        expect(result.definitions).toHaveLength(1);
+        expect(result.definitions[0]?.pos).toBe("noun");
+        expect(result.definitions[0]?.senses[0]?.glosses).toContain("house");
+    });
 
-  it("returns multiple POS entries for polysemous words", async () => {
-    const event = createTestEvent({ edition: "en", word: "run" });
-    const result = definitionsHandler(event);
+    it("returns multiple POS entries for polysemous words", async () => {
+        const event = createTestEvent({ edition: "en", word: "run" });
+        const result = definitionsHandler(event);
 
-    const posList = result.definitions.map((d) => d.pos).filter(Boolean);
-    expect(posList).toContain("noun");
-    expect(posList).toContain("verb");
-  });
+        const posList = result.definitions.map((d) => d.pos).filter(Boolean);
+        expect(posList).toContain("noun");
+        expect(posList).toContain("verb");
+    });
 });
 
 // ── /word/{word}/translations ─────────────────────────────────────────────────
 
 describe("GET /v1/{edition}/word/{word}/translations", () => {
-  it("returns translations array", async () => {
-    const event = createTestEvent({ edition: "en", word: "run" }, { lang: "en" });
-    const result = translationsHandler(event);
+    it("returns translations array", async () => {
+        const event = createTestEvent({ edition: "en", word: "run" }, { lang: "en" });
+        const result = translationsHandler(event);
 
-    const verbEntry = result.translations.find((t) => t.pos === "verb");
-    expect(verbEntry?.translations).toHaveLength(1);
-    expect(verbEntry?.translations[0].word).toBe("courir");
-  });
+        const verbEntry = result.translations.find((t) => t.pos === "verb");
+        expect(verbEntry?.translations).toHaveLength(1);
+        expect(verbEntry?.translations[0].word).toBe("courir");
+    });
 
-  it("returns empty translations for entries without them", async () => {
-    const event = createTestEvent({ edition: "en", word: "Haus" });
-    const result = translationsHandler(event);
+    it("returns empty translations for entries without them", async () => {
+        const event = createTestEvent({ edition: "en", word: "Haus" });
+        const result = translationsHandler(event);
 
-    expect(result.translations[0]?.translations).toHaveLength(0);
-  });
+        expect(result.translations[0]?.translations).toHaveLength(0);
+    });
 });
 
 // ── /word/{word}/pronunciations ───────────────────────────────────────────────
 
 describe("GET /v1/{edition}/word/{word}/pronunciations", () => {
-  it("returns IPA for French chat", async () => {
-    const event = createTestEvent({ edition: "en", word: "chat" }, { lang: "fr" });
-    const result = pronunciationsHandler(event);
+    it("returns IPA for French chat", async () => {
+        const event = createTestEvent({ edition: "en", word: "chat" }, { lang: "fr" });
+        const result = pronunciationsHandler(event);
 
-    expect(result.pronunciations[0]?.sounds[0]?.ipa).toBe("/ʃa/");
-  });
+        expect(result.pronunciations[0]?.sounds[0]?.ipa).toBe("/ʃa/");
+    });
 
-  it("returns IPA for German Haus", async () => {
-    const event = createTestEvent({ edition: "en", word: "Haus" });
-    const result = pronunciationsHandler(event);
+    it("returns IPA for German Haus", async () => {
+        const event = createTestEvent({ edition: "en", word: "Haus" });
+        const result = pronunciationsHandler(event);
 
-    expect(result.pronunciations[0]?.sounds[0]?.ipa).toBe("/haʊ̯s/");
-  });
+        expect(result.pronunciations[0]?.sounds[0]?.ipa).toBe("/haʊ̯s/");
+    });
 });
 
 // ── /word/{word}/forms ────────────────────────────────────────────────────────
 
 describe("GET /v1/{edition}/word/{word}/forms", () => {
-  it("returns inflected forms for German Haus", async () => {
-    const event = createTestEvent({ edition: "en", word: "Haus" });
-    const result = formsHandler(event);
+    it("returns inflected forms for German Haus", async () => {
+        const event = createTestEvent({ edition: "en", word: "Haus" });
+        const result = formsHandler(event);
 
-    const forms = result.forms[0]?.forms;
-    expect(forms.some((f: { form: string }) => f.form === "Hauses")).toBe(true);
-    expect(forms.some((f: { form: string }) => f.form === "Häuser")).toBe(true);
-  });
+        const forms = result.forms[0]?.forms;
+        expect(forms.some((f: { form: string }) => f.form === "Hauses")).toBe(true);
+        expect(forms.some((f: { form: string }) => f.form === "Häuser")).toBe(true);
+    });
 
-  it("returns empty forms for uninflected entries", async () => {
-    const event = createTestEvent({ edition: "en", word: "run" }, { lang: "en" });
-    const result = formsHandler(event);
+    it("returns empty forms for uninflected entries", async () => {
+        const event = createTestEvent({ edition: "en", word: "run" }, { lang: "en" });
+        const result = formsHandler(event);
 
-    const nounForms = result.forms.find((f) => f.pos === "noun");
-    expect(nounForms?.forms).toHaveLength(0);
-  });
+        const nounForms = result.forms.find((f) => f.pos === "noun");
+        expect(nounForms?.forms).toHaveLength(0);
+    });
 });

--- a/packages/api/tests/routes/words.test.ts
+++ b/packages/api/tests/routes/words.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vite-plus/test";
+import { createTestEvent, call } from "../helpers/event.ts";
+import wordsGetHandler from "../../routes/v1/[edition]/words.get";
+
+describe("GET /v1/{edition}/words", () => {
+    it("returns entries for multiple words", async () => {
+        const event = createTestEvent({ edition: "en" }, { words: "run,chat" });
+        const result = wordsGetHandler(event);
+
+        expect(result.results).toHaveLength(2);
+        expect(result.results[0].word).toBe("run");
+        expect(result.results[0].entries).not.toBeNull();
+        expect(result.results[1].word).toBe("chat");
+        expect(result.results[1].entries).not.toBeNull();
+    });
+
+    it("returns error for not-found words", async () => {
+        const event = createTestEvent({ edition: "en" }, { words: "run,xyznotfound" });
+        const result = wordsGetHandler(event);
+
+        expect(result.results).toHaveLength(2);
+        expect(result.results[0].word).toBe("run");
+        expect(result.results[0].entries).not.toBeNull();
+        expect(result.results[1].word).toBe("xyznotfound");
+        expect(result.results[1].entries).toBeNull();
+        expect(result.results[1].error).toBe("Word not found");
+    });
+
+    it("filters by lang when ?lang= is provided", async () => {
+        const event = createTestEvent({ edition: "en" }, { words: "chat", lang: "fr" });
+        const result = wordsGetHandler(event);
+
+        expect(result.results).toHaveLength(1);
+        expect(result.results[0].entries).toHaveLength(1);
+        expect(result.results[0].entries![0].senses[0].glosses).toContain("cat");
+    });
+
+    it("returns 400 when words param is missing", async () => {
+        const event = createTestEvent({ edition: "en" }, {});
+        await expect(call(wordsGetHandler, event)).rejects.toSatisfy(
+            (e: any) => e.statusCode === 400,
+        );
+    });
+
+    it("handles single word", async () => {
+        const event = createTestEvent({ edition: "en" }, { words: "run" });
+        const result = wordsGetHandler(event);
+
+        expect(result.results).toHaveLength(1);
+        expect(result.results[0].word).toBe("run");
+        expect(result.results[0].entries).not.toBeNull();
+    });
+
+    it("handles words with whitespace in comma-separated list", async () => {
+        const event = createTestEvent({ edition: "en" }, { words: "run , chat " });
+        const result = wordsGetHandler(event);
+
+        expect(result.results).toHaveLength(2);
+        expect(result.results[0].word).toBe("run");
+        expect(result.results[1].word).toBe("chat");
+    });
+});

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": ["nitro/tsconfig"],
-  "compilerOptions": {
-    "composite": true,
-    "noEmit": false,
-    "rewriteRelativeImportExtensions": true,
-    "outDir": "./.tsbuild",
-    "paths": {
-      "~/*": ["./*"]
+    "extends": ["nitro/tsconfig"],
+    "compilerOptions": {
+        "composite": true,
+        "noEmit": false,
+        "rewriteRelativeImportExtensions": true,
+        "outDir": "./.tsbuild",
+        "paths": {
+            "~/*": ["./*"]
+        }
     }
-  }
 }

--- a/packages/api/utils/queries.ts
+++ b/packages/api/utils/queries.ts
@@ -2,12 +2,13 @@ import { HTTPError } from "nitro/h3";
 import { db } from "./db.ts";
 
 export interface EntryRow {
-  pos: string | null;
-  lang_code: string;
-  senses: string;
-  sounds: string | null;
-  translations: string | null;
-  forms: string | null;
+    pos: string | null;
+    word: string;
+    lang_code: string;
+    senses: string;
+    sounds: string | null;
+    translations: string | null;
+    forms: string | null;
 }
 
 /**
@@ -15,27 +16,97 @@ export interface EntryRow {
  * Throws a 404 if no entries are found.
  */
 export function fetchWordEntries(edition: string, word: string, lang?: string): EntryRow[] {
-  const rows = (
-    lang
-      ? db
-          .prepare(
-            `SELECT pos, lang_code, senses, sounds, translations, forms FROM entries
+    const rows = (
+        lang
+            ? db
+                  .prepare(
+                      `SELECT pos, lang_code, senses, sounds, translations, forms FROM entries
              WHERE edition = ? AND word = ? AND lang_code = ?
              ORDER BY pos`,
-          )
-          .all(edition, word, lang)
-      : db
-          .prepare(
-            `SELECT pos, lang_code, senses, sounds, translations, forms FROM entries
+                  )
+                  .all(edition, word, lang)
+            : db
+                  .prepare(
+                      `SELECT pos, lang_code, senses, sounds, translations, forms FROM entries
              WHERE edition = ? AND word = ?
              ORDER BY lang_code, pos`,
-          )
-          .all(edition, word)
-  ) as EntryRow[];
+                  )
+                  .all(edition, word)
+    ) as EntryRow[];
 
-  if (rows.length === 0) {
-    throw new HTTPError({ statusCode: 404, message: `No entries found for "${word}"` });
-  }
+    if (rows.length === 0) {
+        throw new HTTPError({ statusCode: 404, message: `No entries found for "${word}"` });
+    }
 
-  return rows;
+    return rows;
+}
+
+export interface BatchEntryResult {
+    word: string;
+    entries: EntryRow[] | null;
+}
+
+/**
+ * Fetch entries for multiple words in a given edition.
+ * Returns results for all words, including those not found (with empty entries array).
+ */
+export function fetchWordEntriesBatch(
+    edition: string,
+    words: string[],
+    lang?: string,
+): BatchEntryResult[] {
+    if (words.length === 0) {
+        return [];
+    }
+
+    const placeholders = words.map(() => "?").join(",");
+    const params: (string | number)[] = [edition, ...words];
+
+    let query: string;
+    if (lang) {
+        query = `
+      SELECT word, pos, lang_code, senses, sounds, translations, forms
+      FROM entries
+      WHERE edition = ? AND word IN (${placeholders}) AND lang_code = ?
+      ORDER BY word, lang_code, pos
+    `;
+        params.push(lang);
+    } else {
+        query = `
+      SELECT word, pos, lang_code, senses, sounds, translations, forms
+      FROM entries
+      WHERE edition = ? AND word IN (${placeholders})
+      ORDER BY word, lang_code, pos
+    `;
+    }
+
+    const rows = db.prepare(query).all(...params) as EntryRow[];
+
+    const results: BatchEntryResult[] = words.map((word) => ({
+        word,
+        entries: null,
+    }));
+
+    const foundWords = new Set<string>();
+    for (const row of rows) {
+        foundWords.add(row.word);
+    }
+
+    for (const row of rows) {
+        const result = results.find((r) => r.word === row.word);
+        if (result) {
+            if (!result.entries) {
+                result.entries = [];
+            }
+            result.entries.push(row);
+        }
+    }
+
+    for (const result of results) {
+        if (!foundWords.has(result.word)) {
+            result.entries = null;
+        }
+    }
+
+    return results;
 }

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -5,15 +5,15 @@ import { fileURLToPath } from "node:url";
 const root = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  root,
-  resolve: {
-    alias: {
-      "~": root,
+    root,
+    resolve: {
+        alias: {
+            "~": root,
+        },
     },
-  },
-  test: {
-    globalSetup: [join(root, "tests/global-setup.ts")],
-    setupFiles: [join(root, "tests/setup.ts")],
-    include: [join(root, "tests/**/*.test.ts")],
-  },
+    test: {
+        globalSetup: [join(root, "tests/global-setup.ts")],
+        setupFiles: [join(root, "tests/setup.ts")],
+        include: [join(root, "tests/**/*.test.ts")],
+    },
 });


### PR DESCRIPTION
Words containing diacritic characters (e.g., café, naïve) were not searchable because URL-encoded parameters weren't being decoded.
Example: https://api.wiktapi.dev/v1/cs/word/pou%C5%BE%C3%ADvat%20?lang=cs 
(word = "používat")